### PR TITLE
Custom tiles controller

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,15 @@
 /* encoding: utf-8 */
 
 
+/* PaperScape map properties */
+export const mapBounds = [[-1750, 250], [-250, 1750]];
+export const mapBoundsViscosity = 0.8;
+export const mapInitialCenter = [-1000, 1000];
+export const mapInitialZoom = 0;
+export const mapZoomDelta = 0.25;
+export const mapZoomSnap = 0.25;
+
+
 /* Color tiles provider */
 export const colorTilesHost = 'https://tile{s}.paperscape.org/world/tiles/{z}/{x}/{y}.png';
 export const colorTilesAttr = '<a href=https://github.com/paperscape>PaperScape</a>';

--- a/src/pages/papers/components/tabs/Map.js
+++ b/src/pages/papers/components/tabs/Map.js
@@ -1,10 +1,10 @@
 /* encoding: utf-8 */
 
 import React, { Component } from "react";
+import CustomCRS from "../../controllers/PapersCRS";
 import PapersTilesLayer from "../../controllers/PapersTilesLayer";
-import { colorTilesHost, colorTilesAttr, greyTilesHost, greyTilesAttr } from "../../../../config";
+import * as config from "../../../../config";
 import { LayersControl, Map } from "react-leaflet";
-import { CRS } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
 
@@ -13,45 +13,46 @@ export default class MapCanvas extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {
-            mapCenter: [-1500, 1500],
-            mapZoom: 0,
-        };
+
+        // Set up at render() time
+        this.map = null;
     }
 
 
     componentDidMount () {
-        const map = this.map.leafletElement;
-        setTimeout(() => map.invalidateSize(), 100);
+        setTimeout(() => this.map.invalidateSize(), 100);
     }
 
 
     render() {
-        const { mapCenter, mapZoom } = this.state;
 
         return (
             // The "ref" prop is necessary to obtain the created instance
             <Map
-                center={mapCenter}
-                zoom={mapZoom}
-                crs={CRS.Simple}
-                ref={(ref) => this.map = ref}
+                center={config.mapInitialCenter}
+                crs={CustomCRS}
+                maxBounds={config.mapBounds}
+                maxBoundsViscosity={config.mapBoundsViscosity}
+                zoom={config.mapInitialZoom}
+                zoomDelta={config.mapZoomDelta}
+                zoomSnap={config.mapZoomSnap}
+                ref={(ref) => this.map = ref.leafletElement}
             >
                 <LayersControl>
                     <LayersControl.BaseLayer
                         checked={false}
                         name="Color">
                         <PapersTilesLayer
-                            url={colorTilesHost}
-                            attribution={colorTilesAttr}
+                            url={config.colorTilesHost}
+                            attribution={config.colorTilesAttr}
                         />
                     </LayersControl.BaseLayer>
                     <LayersControl.BaseLayer
                         checked={true}
                         name="Greyscale">
                         <PapersTilesLayer
-                            url={greyTilesHost}
-                            attribution={greyTilesAttr}
+                            url={config.greyTilesHost}
+                            attribution={config.greyTilesAttr}
                         />
                     </LayersControl.BaseLayer>
                 </LayersControl>

--- a/src/pages/papers/controllers/PapersCRS.js
+++ b/src/pages/papers/controllers/PapersCRS.js
@@ -1,0 +1,15 @@
+/* encoding: utf-8 */
+
+import { CRS } from "leaflet";
+
+
+const CustomCRS = CRS.Simple;
+
+// Overriding CRS.Simple scale function
+CustomCRS.scale = function(zoom) {
+    // The 0.55 offset is a magic number
+    return Math.pow(2, zoom) + 0.55;
+};
+
+
+export default CustomCRS;

--- a/src/pages/papers/controllers/PapersTilesLayer.js
+++ b/src/pages/papers/controllers/PapersTilesLayer.js
@@ -13,7 +13,6 @@ class PaperscapeTiles extends GridLayer {
         options.minZoom = 0;
         options.maxZoom = 6;
         options.tileSize = 512;
-        options.noWrap = true;
         options.continuousWorld = true;
         options.subdomains = ["1", "2", "3", "4"];
 


### PR DESCRIPTION
This PR includes custom components for dealing with PaperScape tiles:

- Custom [TileLayer](https://leafletjs.com/reference-1.6.0.html#tilelayer) React component, to specify desired options and specific subdomains.
- Custom CRS system, based on the _"[CRS Simple](https://leafletjs.com/reference-1.6.0.html#crs-l-crs-simple)"_, but modifying the scale factors.