### PR TITLE
Fix semantic-ui-css version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react-leaflet": "^3.2.5",
         "react-router-dom": "^5.3.0",
         "react-scripts": "^5.0.0",
-        "semantic-ui-css": "^2.4.1",
+        "semantic-ui-css": "git+https://github.com/Semantic-Org/Semantic-UI-CSS.git",
         "semantic-ui-react": "^2.1.1"
       },
       "devDependencies": {
@@ -15638,8 +15638,8 @@
     },
     "node_modules/semantic-ui-css": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
+      "resolved": "git+ssh://git@github.com/Semantic-Org/Semantic-UI-CSS.git#01e4a5346496c284db3b19a102458731ccccd911",
+      "license": "MIT",
       "dependencies": {
         "jquery": "x.*"
       }
@@ -29148,9 +29148,8 @@
       }
     },
     "semantic-ui-css": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
-      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
+      "version": "git+ssh://git@github.com/Semantic-Org/Semantic-UI-CSS.git#01e4a5346496c284db3b19a102458731ccccd911",
+      "from": "semantic-ui-css@git+https://github.com/Semantic-Org/Semantic-UI-CSS.git",
       "requires": {
         "jquery": "x.*"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react-leaflet": "^3.2.5",
     "react-router-dom": "^5.3.0",
     "react-scripts": "^5.0.0",
-    "semantic-ui-css": "^2.4.1",
+    "semantic-ui-css": "git+https://github.com/Semantic-Org/Semantic-UI-CSS.git",
     "semantic-ui-react": "^2.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR pins `semantic-ui-css` version to its GitHub master branch until a new release is uploaded to [npm](https://www.npmjs.com/package/semantic-ui-css) ([tracking issue](https://github.com/Semantic-Org/Semantic-UI-CSS/issues/81)). The previous version (`2.4.1`) is incompatible with Webpack 5.