### PR TITLE
Upgrade Node to version 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
 
-  check:
+  lint:
     needs: []
     runs-on: ubuntu-20.04
     steps:
@@ -30,7 +30,7 @@ jobs:
         run: make check
 
   test:
-    needs: [check]
+    needs: [lint]
     runs-on: ubuntu-20.04
     steps:
       - name: "Set up GitHub Actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: "Setup node"
         uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 16
       - name: "Install Prettier"
         run: npm install --global prettier@2.5.0
       - name: "Check code format"
@@ -38,7 +38,7 @@ jobs:
       - name: "Setup node"
         uses: actions/setup-node@v2
         with:
-          node-version: 15
+          node-version: 16
       - name: "Install dependencies"
         run: npm install-clean
       - name: "Run tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,5 @@ jobs:
     steps:
       - name: "Set up GitHub Actions"
         uses: actions/checkout@v2
-      - name: "Setup node"
-        uses: actions/setup-node@v2
-        with:
-          node-version: 15
-      - name: "Install dependencies"
-        run: npm install-clean
-      - name: "Run tests"
-        run: make build
+      - name: "Build Docker image"
+        run: make docker-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image
-FROM node:15.14-alpine
+FROM node:16.14-alpine
 
 # Set working directory and copy files
 WORKDIR /app


### PR DESCRIPTION
~This PR addresses issue https://github.com/dialect-map/dialect-map-ui/issues/62 by redefining the CI workflow `check` step to check for the [package-lock.json](https://github.com/dialect-map/dialect-map-ui/blob/main/package-lock.json) file integrity (whether or not it is synchronized with the `package.json` spec).~

~This validation is designed to be CI-exlusive, as local environment may yield false-positives.~

**EDIT:**

Given that the `package.json` <-> `package-lock.json` sync check bug will _auto-resolve_ when a recent enough version of npm ([npm 8.4.1](https://github.com/npm/cli/releases/tag/v8.4.1) forward) is used, this PR has been re-purposed to:

- Standardize [CI workflow](https://github.com/dialect-map/dialect-map-ui/blob/main/.github/workflows/ci.yml) step names.
- Upgrade Node environment to version 16.